### PR TITLE
fix udp port leak in heartbeatNAT

### DIFF
--- a/cmd/client/nat.go
+++ b/cmd/client/nat.go
@@ -102,6 +102,7 @@ func heartbeatNAT(ip net.IP, port int, errCh chan<- error) {
 		continuousErrorCount++
 		if continuousErrorCount > heartbeatMaxError {
 			errCh <- fmt.Errorf("failed to heartbeat continuously, the last error: %w", err)
+			return
 		}
 	}
 }


### PR DESCRIPTION
When conn.Read() fail 3 times,  eg. udp read timeout, will write err to errCh, which makes nat() exit. But heartbeatNAT() not exit, defer conn.Close() won't be called.

nat() will be called again in for loop of main(),  start a new go heartbeatNAT(), ListenUDP a new udp port. So a udp port is leaked